### PR TITLE
basic server/api for datafeed test database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ cython_debug/
 
 # pyenv
 .python-version
+
+# test databases
+*.db
+*.sqlite3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+aiosqlite==0.17.0
+asgiref==3.4.1
+click==8.0.1
+databases==0.5.1
+fastapi==0.68.1
+greenlet==1.1.1
+h11==0.12.0
+mypy==0.910
+mypy-extensions==0.4.3
+pydantic==1.8.2
+SQLAlchemy==1.4.23
+starlette==0.14.2
+toml==0.10.2
+typing-extensions==3.10.0.2
+uvicorn==0.15.0

--- a/src/telliot/datafeed/db.py
+++ b/src/telliot/datafeed/db.py
@@ -1,4 +1,28 @@
 """ Feeder database module
 
-This module provides an interface to read/write the feeder database
+This module creates a database with a model to store off-chain data.
 """
+import databases
+import sqlalchemy  # type: ignore
+
+
+DATABASE_URL = "sqlite:///./test.db"
+
+database = databases.Database(DATABASE_URL)
+
+metadata = sqlalchemy.MetaData()
+
+offchain = sqlalchemy.Table(
+    "offchain",
+    metadata,
+    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column("name", sqlalchemy.String),
+    sqlalchemy.Column("value", sqlalchemy.String),
+    sqlalchemy.Column("timestamp", sqlalchemy.DateTime),
+)
+
+engine = sqlalchemy.create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+metadata.create_all(engine)

--- a/src/telliot/datafeed/schemas.py
+++ b/src/telliot/datafeed/schemas.py
@@ -1,0 +1,32 @@
+"""API Models
+
+This module builds Pydantic models used for
+enforcing data types when creating and reading
+with the datafeed api.
+"""
+
+from pydantic import BaseModel
+import datetime
+
+
+class DataIn(BaseModel):
+    '''Ingested data model.
+
+    Standardize data ingested to database using typing.
+    Ingested data does not include auto-generated ids.
+    '''
+    name: str
+    value: str
+    timestamp: datetime.datetime
+
+
+class Data(BaseModel):
+    '''Retrieved data model.
+
+    Standardize data queried from the database using typing.
+    Retrieved data includes the auto-generated id for the row.
+    '''
+    id: int
+    name: str
+    value: str
+    timestamp: datetime.datetime

--- a/src/telliot/datafeed/server.py
+++ b/src/telliot/datafeed/server.py
@@ -1,5 +1,5 @@
 """ Database Server
 
-This module provides API (read-only) access to the datafeed database through
+This module provides API access to the datafeed database through
 a local server port.
 """

--- a/src/telliot/datafeed/server.py
+++ b/src/telliot/datafeed/server.py
@@ -1,5 +1,73 @@
-""" Database Server
+""" Database API Server
 
 This module provides API access to the datafeed database through
 a local server port.
 """
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Mapping
+from typing import Optional
+
+from fastapi import FastAPI
+
+from . import db
+from . import schemas
+
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    """Connect database.
+
+    Connects to local postgresql database on server startup.
+    """
+    await db.database.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    """Disconnect database.
+
+    Disconnects local postgresql database on server shutdown.
+    """
+    await db.database.disconnect()
+
+
+@app.post("/data/", response_model=schemas.Data)
+async def create_data(data: schemas.DataIn) -> Dict[str, Any]:
+    """Add data.
+
+    Store new data in connected postgresql database.
+    """
+    query = db.offchain.insert().values(
+        name=data.name, value=data.value, timestamp=data.timestamp
+    )
+    last_record_id = await db.database.execute(query)
+    return {**data.dict(), "id": last_record_id}
+
+
+@app.get("/data/", response_model=List[schemas.Data])
+async def get_all() -> List[Mapping[str, Any]]:
+    """Get all data.
+
+    Retrieves all off-chain data stored in connected database.
+    """
+    query = db.offchain.select()
+    return await db.database.fetch_all(query)
+
+
+@app.get("/data/get/", response_model=schemas.Data)
+async def get_latest_by_name(name: str) -> Optional[Mapping[str, Any]]:
+    """Get last entry for specified data.
+
+    Retrieves one data entry based on given name.
+    """
+    query = f"""
+    select * from offchain
+    where name = "{name}"
+    order by timestamp desc limit 1
+    """
+    return await db.database.fetch_one(query)

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ skip_install = true
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:typing]
-deps = mypy
+deps = -rrequirements.txt
 commands = mypy src --strict --disable-error-code misc
 
 [testenv:docs]


### PR DESCRIPTION
To use, install the dependencies in `requirements.txt` to your `venv`, then in `src/` run `uvicorn datafeed.server:app --reload` to start the server. You can interact with the api through a simple UI at `http://127.0.0.1:8000/docs` once the server's running, or view the entire datafeed at `http://127.0.0.1:8000/data`.

Still working on switching to postgresql, rather than the sqlite test database. `database.py` needs to be made more testable and some basic tests need to be added for the api, among other needed improvements.

Cast data as `str` for the test database, but we'll be able to store data as bytes with postgresql.