### PR TITLE
fix tox style errors

### DIFF
--- a/src/telliot/utils/contract.py
+++ b/src/telliot/utils/contract.py
@@ -1,11 +1,9 @@
 """
 Utils for connecting to an EVM contract
 """
-
 import web3
-from telliot.utils.rpc_endpoint import RPCEndpoint
-
 from pydantic.dataclasses import dataclass
+from telliot.utils.rpc_endpoint import RPCEndpoint
 
 
 @dataclass

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,9 +1,7 @@
 """
 Test covering Pytelliot EVM contract connection utils.
 """
-
 import web3
-
 from telliot.utils.contract import Contract
 from telliot.utils.rpc_endpoint import RPCEndpoint
 
@@ -13,6 +11,7 @@ with open("abi.json") as f:
 network = "mainnet"
 provider = "pokt"
 
+
 def test_read_tellor_playground():
     """Contract object should access Tellor Playground functions"""
     contract = connect_to_contract("0x4699845F22CA2705449CFD532060e04abE3F1F31")
@@ -20,6 +19,8 @@ def test_read_tellor_playground():
     assert isinstance(
         contract.web3_contract.all_functions()[0], web3.contract.ContractFunction
     )
+
+
 def connect_to_contract(address):
     """Helper function for connecting to a contract at an address"""
     url = "https://mainnet.infura.io/v3/1a09c4705f114af2997548dd901d655b"

--- a/tests/test_rpc_endpoint.py
+++ b/tests/test_rpc_endpoint.py
@@ -42,6 +42,7 @@ def test_incomplete_rpc_url():
     with pytest.raises(requests.exceptions.HTTPError):
         endpt.web3.eth.block_number
 
+
 def test_load_from_config():
     """RPCEndpoint should read from config.yml"""
     pass


### PR DESCRIPTION
Failed on order of import statements, and so it also didn't get to do any of the other style checks. Fixed by deleting my cached tox style env and running `tox -e style` a few times.