### PR TITLE
New Base classes for Application and Configuration objects

### DIFF
--- a/src/telliot/utils/app.py
+++ b/src/telliot/utils/app.py
@@ -157,14 +157,3 @@ class Application(BaseModel):
 
         print("Application {} received shutdown event".format(self.name))
         self._shutdown.clear()
-
-
-if __name__ == "__main__":
-    """Simple application demonstration"""
-
-    import time
-
-    a = Application(name="myapp")
-    a.startup()
-    time.sleep(5)
-    a.shutdown()

--- a/src/telliot/utils/app.py
+++ b/src/telliot/utils/app.py
@@ -1,8 +1,18 @@
 """ Telliot application helpers
 
 """
+import logging
 import pathlib
+import threading
 from pathlib import Path
+from typing import Any
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import PrivateAttr
+from telliot.utils.config import ConfigOptions
+
+logger = logging.getLogger(__name__)
 
 
 def default_homedir() -> pathlib.Path:
@@ -11,9 +21,150 @@ def default_homedir() -> pathlib.Path:
     Returns:
         pathlib.Path : Path to home directory
     """
-    homedir = Path.home() / (".telliot")
+    homedir = Path.home() / ("telliot")
     homedir = homedir.resolve().absolute()
     if not homedir.is_dir():
         homedir.mkdir()
 
     return homedir
+
+
+class Application(BaseModel):
+    """Application base class"""
+
+    #: Application Name
+    name: str
+
+    #: Home directory
+    homedir: Optional[Path]
+
+    #: Configuration file
+    #: If not provided, default is <name>.yaml in homedir
+    config_file: Optional[Path]
+
+    #: Application configuration object
+    config: Optional[ConfigOptions]
+
+    #: Private thread storage
+    _thread: Optional[threading.Thread] = PrivateAttr()
+    _shutdown: threading.Event = PrivateAttr(default_factory=threading.Event)
+
+    def __init__(self, **kwargs: Any) -> None:
+
+        # Pydantic initialization
+        super().__init__(**kwargs)
+
+        # Home Directory
+        if self.homedir is None:
+            # Set default homedir and create if necessary
+            self.homedir = default_homedir()
+            if not self.homedir.exists():
+                self.homedir.mkdir(parents=True)
+        else:
+            # Use specified home directory
+            self.homedir = self.homedir.resolve().absolute()
+            if not self.homedir.exists():
+                raise FileExistsError(
+                    "Directory does not exist: {}".format(self.homedir)
+                )
+
+        # Configuration
+
+        if self.config_file is None:
+            # If no config file was passed in, use default file
+            self.config_file = self.homedir / (self.name + ".yaml")
+        elif isinstance(self.config_file, str):
+            self.config_file = Path(self.config_file)
+
+        if not self.config:
+            # If a config was not passed in, try to load it from the file
+            if self.config_file.exists():
+                self.config = ConfigOptions.from_file(self.config_file)
+
+            # Otherwise, create and store a default config
+            else:
+                self.config = self.get_default_config()
+                self.config.to_file(self.config_file)
+
+        # Logging
+        self.configure_logging()
+
+        logger.info("Created new {} application object".format(self.name))
+        logger.info("Home Directory: {}".format(self.homedir))
+        logger.info("Config file: {}".format(self.config_file))
+
+    def get_default_config(self) -> ConfigOptions:
+        """Return the default application configuration object
+
+        Subclasses may override this method as required
+        """
+        return ConfigOptions()
+
+    def configure_logging(self) -> None:
+        """Configure Application logging
+
+        Subclasses may override this method as required
+        """
+
+        # type checking does not seem to recognize that config
+        # and homedir were validated/coerced in __init__
+        assert self.config is not None
+        assert isinstance(self.homedir, Path)
+
+        # Convert loglevel string to log type
+        loglevel = eval("logging." + self.config.loglevel.upper())
+
+        logfile = self.homedir / (self.name + ".log")
+        logging.basicConfig(filename=str(logfile), level=loglevel)
+
+    def startup(self) -> None:
+        """Startup Application
+
+        Start the main application thread
+        """
+        logger.info("Starting {} Application".format(self.name))
+        self._thread = threading.Thread(target=self.main, name=self.name)
+        self._thread.start()
+
+    def shutdown(self) -> None:
+        """Startup Application
+
+        Send a shutdown event to the main application thread and wait
+        for it to terminate.
+        """
+        if self._thread:
+            logger.info("Terminating {} Application".format(self.name))
+
+            self._shutdown.set()
+
+            #: Join worker thread
+            self._thread.join()
+
+            self._thread = None
+
+    def main(self) -> None:
+        """Main worker thread
+
+        This method defined the main application processing.
+        The main thread must monitor and respond to the self._shutdown event.
+
+        This method *must* be overridded by subclasses.
+        """
+        seconds = 0
+        while not self._shutdown.wait(1.0):
+            print("Main thread processing: {}".format(seconds))
+            seconds += 1
+
+        print("Application {} received shutdown event".format(self.name))
+        self._shutdown.clear()
+
+
+if __name__ == "__main__":
+    """Simple application demonstration"""
+
+    import time
+
+    a = Application(name="myapp")
+    a.startup()
+    time.sleep(5)
+    a.shutdown()

--- a/src/telliot/utils/config.py
+++ b/src/telliot/utils/config.py
@@ -1,27 +1,30 @@
-import pathlib
-
-from pydantic import BaseModel
 import enum
-import yaml
-from yaml import CLoader as Loader, CDumper as Dumper
+import pathlib
 from typing import Union
+
+import yaml
+from pydantic import BaseModel
+from yaml import CDumper as Dumper
+from yaml import CLoader as Loader
 
 
 class LogLevel(str, enum.Enum):
     """Enumeration of supported log levels"""
-    DEBUG = 'debug'
-    INFO = 'info'
-    WARNING = 'warning'
-    ERROR = 'error'
-    CRITICAL = 'critical'
+
+    DEBUG = "debug"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+    CRITICAL = "critical"
 
 
 class ConfigOptions(BaseModel):
-    """ An object used to manage configuration options
+    """An object used to manage configuration options
 
     Each attribute represents an option in the config file.
     This object can be subclassed to add parameters.
     """
+
     loglevel: LogLevel = LogLevel.INFO
 
     class Config:
@@ -30,28 +33,26 @@ class ConfigOptions(BaseModel):
 
     @classmethod
     def from_file(cls, filename: Union[str, pathlib.Path]) -> "ConfigOptions":
-        """ Load Configuration from a .yaml file
+        """Load Configuration from a .yaml file
 
         Parameters
         ----------
         filename
         """
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             state = yaml.load(f, Loader=Loader)
 
         return cls.parse_obj(state)
 
     def to_file(self, filename: Union[str, pathlib.Path]) -> None:
-        """ Save configuration to a file
-
-        """
+        """Save configuration to a file"""
         try:
-            with open(filename, 'w') as f:
+            with open(filename, "w") as f:
                 state = self.dict()
                 print(state)
                 yaml.dump(state, f, Dumper=Dumper)
-                print('Saved configuration to {}'.format(filename))
+                print("Saved configuration to {}".format(filename))
 
         except FileNotFoundError as e:
-            print('Error writing config file {}'.format(filename))
+            print("Error writing config file {}".format(filename))
             raise e

--- a/src/telliot/utils/config.py
+++ b/src/telliot/utils/config.py
@@ -1,0 +1,57 @@
+import pathlib
+
+from pydantic import BaseModel
+import enum
+import yaml
+from yaml import CLoader as Loader, CDumper as Dumper
+from typing import Union
+
+
+class LogLevel(str, enum.Enum):
+    """Enumeration of supported log levels"""
+    DEBUG = 'debug'
+    INFO = 'info'
+    WARNING = 'warning'
+    ERROR = 'error'
+    CRITICAL = 'critical'
+
+
+class ConfigOptions(BaseModel):
+    """ An object used to manage configuration options
+
+    Each attribute represents an option in the config file.
+    This object can be subclassed to add parameters.
+    """
+    loglevel: LogLevel = LogLevel.INFO
+
+    class Config:
+        # Export price_type as string
+        use_enum_values = True
+
+    @classmethod
+    def from_file(cls, filename: Union[str, pathlib.Path]) -> "ConfigOptions":
+        """ Load Configuration from a .yaml file
+
+        Parameters
+        ----------
+        filename
+        """
+        with open(filename, 'r') as f:
+            state = yaml.load(f, Loader=Loader)
+
+        return cls.parse_obj(state)
+
+    def to_file(self, filename: Union[str, pathlib.Path]) -> None:
+        """ Save configuration to a file
+
+        """
+        try:
+            with open(filename, 'w') as f:
+                state = self.dict()
+                print(state)
+                yaml.dump(state, f, Dumper=Dumper)
+                print('Saved configuration to {}'.format(filename))
+
+        except FileNotFoundError as e:
+            print('Error writing config file {}'.format(filename))
+            raise e

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,14 @@
 """ Test application utilities
 
 """
+import os
 import pathlib
+import shutil
+import threading
+import time
 
+import pytest
+from telliot.utils.app import Application
 from telliot.utils.app import default_homedir
 
 
@@ -11,3 +17,34 @@ def test_homedir():
     hd = default_homedir()
     assert isinstance(hd, pathlib.Path)
     assert hd.exists()
+
+
+def test_application():
+    """Test application features"""
+
+    testhome = "./tmpapp"
+    if pathlib.Path(testhome).exists():
+        shutil.rmtree(testhome)
+
+    #: Create an application with the default home directory
+    app = Application(name="appname")
+    assert app.homedir == default_homedir()
+
+    with pytest.raises(FileExistsError):
+        app = Application(name="appname", homedir=testhome)
+
+    os.mkdir(testhome)
+    app = Application(name="appname", homedir=testhome)
+    assert isinstance(app.homedir, pathlib.Path)
+
+    shutil.rmtree(testhome)
+
+
+def test_application_proc():
+    """Test application startup and shutdown"""
+    app = Application(name="testapp")
+    assert isinstance(app._shutdown, threading.Event)
+    a = Application(name="myapp")
+    a.startup()
+    time.sleep(2)
+    a.shutdown()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,28 +1,28 @@
 import os
+
 from telliot.utils.config import ConfigOptions
 from telliot.utils.config import LogLevel
 
 
 def test_config_options():
     c = ConfigOptions()
-    c.to_file('temp.yaml')
+    c.to_file("temp.yaml")
 
 
 def test_config_constructor():
-    """ Test Constructor
-    """
+    """Test Constructor"""
     cfg = ConfigOptions()
     # state = cfg.__getstate__()
-    assert cfg.loglevel.name == 'INFO'
+    assert cfg.loglevel.name == "INFO"
 
 
 def test_store_and_load_file():
     # Create a configuration and store it to a file
     cfg = ConfigOptions(loglevel=LogLevel.CRITICAL)
-    _ = cfg.to_file('tempfile.yaml')
+    _ = cfg.to_file("tempfile.yaml")
 
     # Class constructor from file
-    cfg2 = ConfigOptions.from_file('tempfile.yaml')
+    cfg2 = ConfigOptions.from_file("tempfile.yaml")
     assert cfg.loglevel == cfg2.loglevel
 
-    os.remove('tempfile.yaml')
+    os.remove("tempfile.yaml")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+import os
+from telliot.utils.config import ConfigOptions
+from telliot.utils.config import LogLevel
+
+
+def test_config_options():
+    c = ConfigOptions()
+    c.to_file('temp.yaml')
+
+
+def test_config_constructor():
+    """ Test Constructor
+    """
+    cfg = ConfigOptions()
+    # state = cfg.__getstate__()
+    assert cfg.loglevel.name == 'INFO'
+
+
+def test_store_and_load_file():
+    # Create a configuration and store it to a file
+    cfg = ConfigOptions(loglevel=LogLevel.CRITICAL)
+    _ = cfg.to_file('tempfile.yaml')
+
+    # Class constructor from file
+    cfg2 = ConfigOptions.from_file('tempfile.yaml')
+    assert cfg.loglevel == cfg2.loglevel
+
+    os.remove('tempfile.yaml')


### PR DESCRIPTION
- New `ConfigOptions` can be read/written from YAML and subclassed to add more config parameters.
- The `Application` base class defines
  - Shared Threading model with Startup and  Shutdown 
  - home directory
  - configuration options
  - logging
- `Application` is intended for subclassing and customization by core components including
  - `ReporterApplication`
  - `TellormonApplication`
  - `FeedDatabaseApplication`
 
For usage, see
- `tests/test_config.py`
- `tests/test_app.py`