### PR TITLE
Link OracleQuery to DataFeed

### DIFF
--- a/src/telliot/datafeed/data_feed.py
+++ b/src/telliot/datafeed/data_feed.py
@@ -6,8 +6,9 @@ from typing import Optional
 from telliot.answer import TimeStampedAnswer
 from telliot.datafeed.data_source import DataSource
 from telliot.datafeed.data_source import DataSourceDb
-from telliot.query_registry import query_registry
 from telliot.query import OracleQuery
+from telliot.query_registry import query_registry
+
 
 class DataFeed(DataSourceDb):
     """Data feed"""
@@ -36,7 +37,7 @@ class DataFeed(DataSourceDb):
         return await gather_inputs()
 
     def get_query(self) -> Optional[OracleQuery]:
-        """ Get target query for this Data Feed
+        """Get target query for this Data Feed
 
         Returns:
             Target query for this DataFeed or None if not found

--- a/src/telliot/datafeed/data_feed.py
+++ b/src/telliot/datafeed/data_feed.py
@@ -1,11 +1,13 @@
 import asyncio
 from typing import Any
 from typing import Dict
+from typing import Optional
 
 from telliot.answer import TimeStampedAnswer
 from telliot.datafeed.data_source import DataSource
 from telliot.datafeed.data_source import DataSourceDb
-
+from telliot.query_registry import query_registry
+from telliot.query import OracleQuery
 
 class DataFeed(DataSourceDb):
     """Data feed"""
@@ -13,8 +15,8 @@ class DataFeed(DataSourceDb):
     #: Data feed sources
     sources: Dict[str, DataSource]
 
-    #: Unique ID of tellor query supported by this feed
-    request_id: str
+    #: Unique Query ID supported by this feed
+    qid: str
 
     async def update_sources(self) -> Dict[str, TimeStampedAnswer[Any]]:
         """Update data feed sources
@@ -32,3 +34,11 @@ class DataFeed(DataSourceDb):
             return dict(zip(keys, values))
 
         return await gather_inputs()
+
+    def get_query(self) -> Optional[OracleQuery]:
+        """ Get target query for this Data Feed
+
+        Returns:
+            Target query for this DataFeed or None if not found
+        """
+        return query_registry.queries.get(self.qid, None)

--- a/src/telliot/datafeed/example.py
+++ b/src/telliot/datafeed/example.py
@@ -43,7 +43,7 @@ data_feeds = {
     "btc-usd-median": AssetPriceFeed(
         name="BTC USD Median Price Feed",
         uid="btc-usd-median",
-        request_id="btc-usd-median",
+        qid="qid-0002",
         asset="btc",
         currency="usd",
         sources=data_sources,

--- a/src/telliot/reporter/simple_interval.py
+++ b/src/telliot/reporter/simple_interval.py
@@ -14,7 +14,6 @@ from telliot.submitter.base import Submitter
 from telliot.utils.abi import tellor_playground_abi
 from web3 import Web3
 
-
 # TODO: placeholder for actual ConfigOptions clas
 temp_config = {"node_url": "", "private_key": ""}
 
@@ -121,7 +120,20 @@ class IntervalReporter(Reporter):
             for uid, datafeed in self.datafeeds.items():
                 if datafeed.value:
                     print(f"Submitting value for {uid}: {datafeed.value.val}")
-                    self.submitter.submit_data(datafeed.value.val, datafeed.request_id)
+                    q = datafeed.get_query()
+                    if q is not None:
+                        """TODO:
+                        - Should encode value using query response type.
+                        - Also use request ID encoded by query
+                        - Decide if these goes here or in submitter.
+                        """
+                        # TODO: Should use query to encode value.  Request ID
+                        #       from query is already in bytes.  Probably
+                        #       be part of submitter
+                        encoded_value = q.response_type.encode(datafeed.value.val)
+                        print(encoded_value)  # Dummy print to pass tox style
+                        request_id_str = "0x" + q.request_id.hex()
+                        self.submitter.submit_data(datafeed.value.val, request_id_str)
                 else:
                     print(f"Skipping submission for {uid}, datafeed value not updated")
 

--- a/tests/test_data_feed.py
+++ b/tests/test_data_feed.py
@@ -5,6 +5,7 @@ import statistics
 
 import pytest
 from telliot.datafeed.example import data_feeds
+from telliot.query import OracleQuery
 
 
 @pytest.mark.asyncio
@@ -20,3 +21,7 @@ async def test_AssetPriceFeed():
 
     # Make sure error is less than decimal tolerance
     assert (price.val - statistics.median([s.val for s in sources])) < 10 ** -6
+
+    # Get query
+    q = btc_usd_median.get_query()
+    assert isinstance(q, OracleQuery)


### PR DESCRIPTION
This PR links the `OracleQuery` to the `DataFeed` so that the `Submitter` and `Reporter` can use the `value` and `request_id` encoding provided by the `OracleQuery`.

#39 WIP