### PR TITLE
RPC Updates

### DIFF
--- a/src/telliot/utils/base.py
+++ b/src/telliot/utils/base.py
@@ -10,3 +10,5 @@ class Base(BaseModel):
     class Config:
         arbitrary_types_allowed = True
         extras = False
+        use_enum_values = True
+        underscore_attrs_are_private = True

--- a/src/telliot/utils/config.py
+++ b/src/telliot/utils/config.py
@@ -5,12 +5,12 @@ from typing import Optional
 from typing import Union
 
 import yaml
-from pydantic import BaseModel
+from telliot.utils.base import Base
 from yaml import CDumper as Dumper
 from yaml import CLoader as Loader
 
 
-class ConfigOptions(BaseModel):
+class ConfigOptions(Base):
     """An object used to manage configuration options
 
     Each attribute represents a configuration option.
@@ -29,11 +29,6 @@ class ConfigOptions(BaseModel):
     @property
     def config_file(self) -> Optional[Path]:
         return self._config_file
-
-    class Config:
-        # Export price_type as string
-        use_enum_values = True
-        underscore_attrs_are_private = True
 
     def __init__(
         self, config_file: Optional[Union[str, Path]] = None, **data: Any

--- a/src/telliot/utils/rpc_endpoint.py
+++ b/src/telliot/utils/rpc_endpoint.py
@@ -22,8 +22,9 @@ class RPCEndpoint(Base):
     #: URL (e.g. 'https://mainnet.infura.io/v3/<project_id>')
     url: str
 
-    #: Web3 Connection
-    web3: Optional[Web3] = None
+    #: Read-only Web3 Connection with private storage
+    web3 = property(lambda self: self._web3)
+    _web3: Optional[Web3] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -35,15 +36,15 @@ class RPCEndpoint(Base):
             True if connection was successful
         """
 
-        if self.web3:
+        if self._web3:
             return True
 
-        self.web3 = Web3(Web3.HTTPProvider(self.url))
+        self._web3 = Web3(Web3.HTTPProvider(self.url))
         try:
-            connected = self.web3.isConnected()
+            connected = self._web3.isConnected()
         # Pokt nodes won't submit isConnected rpc call
         except Exception:
-            connected = self.web3.eth.get_block_number() > 1
+            connected = self._web3.eth.get_block_number() > 1
         if connected:
             print("Connected to {}".format(self))
         else:

--- a/src/telliot/utils/rpc_endpoint.py
+++ b/src/telliot/utils/rpc_endpoint.py
@@ -26,9 +26,6 @@ class RPCEndpoint(Base):
     web3 = property(lambda self: self._web3)
     _web3: Optional[Web3] = None
 
-    class Config:
-        arbitrary_types_allowed = True
-
     def connect(self) -> bool:
         """Connect to EVM blockchain
 


### PR DESCRIPTION
Made the `.web3` attribute a read-only private attribute.
This removes an empty (and unnecessary) `web3: null` field from config files.
Otherwise, the changes should be transparent.