### PR TITLE
Remove  --show-diff-on-failure

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
 [testenv:style]
 deps = pre-commit
 skip_install = true
-commands = pre-commit run --all-files --show-diff-on-failure
+commands = pre-commit run --all-files
 
 [testenv:typing]
 deps =


### PR DESCRIPTION
Proposing that we remove the ` --show-diff-on-failure` flag form pre-commit.  

When running `tox -e style`, it dumps a ton of limited use info to the display.  Then a ton of scrollback to see actual errors.