### PR TITLE
add error handling for replacement gp too low

### DIFF
--- a/src/telliot/submitter/base.py
+++ b/src/telliot/submitter/base.py
@@ -6,9 +6,11 @@ to the Tellor oracle.
 """
 import json
 from abc import ABC
+from types import SimpleNamespace
 from typing import Any
 from typing import Mapping
 from typing import Sequence
+from typing import Tuple
 
 import requests
 from telliot.model.endpoints import RPCEndpoint
@@ -69,26 +71,36 @@ class Submitter(ABC):
 
         return built_tx
 
-    def submit_data(self, value: bytes, request_id: str) -> Any:
+    def submit_data(
+        self, value: bytes, request_id: str, extra_gas_price: int = 0
+    ) -> Tuple[Any, SimpleNamespace]:
         """Submits data on-chain & provides a link to view the
         successful transaction."""
+        try:
+            status = SimpleNamespace(**{"error": None, "gas_price": None})
 
-        req = requests.get("https://ethgasstation.info/json/ethgasAPI.json")
-        prices = json.loads(req.content)
-        gas_price = str(prices["fast"])
-        print("retrieved gas price:", gas_price)
-        # gas_price = "3"
-        # print("gas price used:", gas_price)
+            req = requests.get("https://ethgasstation.info/json/ethgasAPI.json")
+            prices = json.loads(req.content)
+            gas_price = str(prices["fast"] + extra_gas_price)
+            status.gas_price = gas_price
 
-        tx = self.build_tx(value, request_id, gas_price)
+            tx = self.build_tx(value, request_id, gas_price)
 
-        tx_signed = self.acc.sign_transaction(tx)
+            tx_signed = self.acc.sign_transaction(tx)
 
-        tx_hash = self.endpoint.web3.eth.send_raw_transaction(tx_signed.rawTransaction)
+            tx_hash = self.endpoint.web3.eth.send_raw_transaction(
+                tx_signed.rawTransaction
+            )
 
-        tx_receipt = self.endpoint.web3.eth.wait_for_transaction_receipt(
-            tx_hash, timeout=360
-        )
-        print(f"View reported data: https://rinkeby.etherscan.io/tx/{tx_hash.hex()}")
+            tx_receipt = self.endpoint.web3.eth.wait_for_transaction_receipt(
+                tx_hash, timeout=360
+            )
+            print(
+                f"View reported data: https://rinkeby.etherscan.io/tx/{tx_hash.hex()}"
+            )
 
-        return tx_receipt
+            return tx_receipt, status
+
+        except Exception as e:
+            status.error = e
+            return None, status

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -57,7 +57,7 @@ def test_reporter_config(cfg):
     assert rinkeby_endpoint.chain_id == 4
 
 
-@pytest.mark.skip(reason="fails sometimes due to wrong gasprice & connection failures")
+# @pytest.mark.skip(reason="fails sometimes due to wrong gasprice & connection failures")
 @pytest.mark.asyncio
 async def test_interval_reporter_submit_once(cfg):
     """Test reporting once to the TellorX playground on Rinkeby
@@ -72,10 +72,9 @@ async def test_interval_reporter_submit_once(cfg):
         datafeeds=data_feeds,
     )
 
-    for _ in range(3):
-        tx_receipts = await reporter.report_once(name="BTC USD Median Price Feed")
-        if tx_receipts:
-            break
+    tx_receipts = await reporter.report_once(
+        name="BTC USD Median Price Feed", retries=3
+    )
 
     assert tx_receipts
 


### PR DESCRIPTION
This PR will un-skip the second test (end-to-end) for the reporter. 
Default retries were added and error handling for replacement transactions with too low gas prices.