### PR TITLE
ContractResponse type implementation

### DIFF
--- a/src/telliot/utils/response.py
+++ b/src/telliot/utils/response.py
@@ -1,0 +1,17 @@
+from typing import Any, Optional
+from telliot.utils.base import Base
+from telliot.model.endpoints import RPCEndpoint
+from telliot.utils.contract import Contract
+
+
+class ContractResponse(Base):
+
+    ok: bool
+
+    result: Optional[Any]
+
+    error: Optional[Exception]
+
+    error_msg: Optional[str]
+
+    endpoint: Optional[RPCEndpoint]


### PR DESCRIPTION
Implement a standard response type for contract calls.
It's attributes:
 ```
ok: bool

result: Optional[Any]

error: Optional[Exception]

error_msg: Optional[str]

endpoint: Optional[RPCEndpoint]
```

Considering adding `Contract` attribute for the sake of application troubleshooting. I'm open to thoughts on this.

Now updating the tests.

Closes #94 
