### PR TITLE
Reduce tox eyesore

### DIFF
--- a/src/telliot/utils/contract.py
+++ b/src/telliot/utils/contract.py
@@ -1,21 +1,18 @@
 """
 Utils for connecting to an EVM contract
 """
-from os import error
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 
 import web3
 from eth_typing.evm import ChecksumAddress
 from telliot.model.endpoints import RPCEndpoint
 from telliot.utils.base import Base
-from web3 import Web3
-
 from telliot.utils.response import ContractResponse
+from web3 import Web3
 
 
 class Contract(Base):
@@ -68,7 +65,9 @@ class Contract(Base):
                 return ContractResponse(ok=True, result=output)
             except ValueError as e:
                 msg = f"function '{func_name}' not found in contract abi"
-                return ContractResponse(ok=False, error=e, error_msg=msg, endpoint=self.node)
+                return ContractResponse(
+                    ok=False, error=e, error_msg=msg, endpoint=self.node
+                )
         else:
             if self.connect():
                 msg = "now connected to contract"

--- a/src/telliot/utils/contract.py
+++ b/src/telliot/utils/contract.py
@@ -36,7 +36,7 @@ class Contract(Base):
     #: global pytelliot configurations
     # config: ConfigOptions
 
-    def connect(self) -> bool:
+    def connect(self) -> ContractResponse:
         """Connect to EVM contract through an RPC Endpoint"""
         if self.node.web3 is None:
             msg = "node is not instantiated"
@@ -51,15 +51,14 @@ class Contract(Base):
             )
             return ContractResponse(ok=True, endpoint=self.node)
 
-    def read(self, func_name: str, **kwargs: Any) -> Tuple[Any, bool]:
+    def read(self, func_name: str, **kwargs: Any) -> ContractResponse:
         """
         Reads data from contract
         inputs:
         func_name (str): name of contract function to call
 
         returns:
-        Tuple: contract function outpus
-        Bool: success
+        ContractResponse: standard response for contract data
         """
 
         if self.contract:

--- a/src/telliot/utils/response.py
+++ b/src/telliot/utils/response.py
@@ -1,8 +1,6 @@
 from typing import Any, Optional
 from telliot.utils.base import Base
 from telliot.model.endpoints import RPCEndpoint
-from telliot.utils.contract import Contract
-
 
 class ContractResponse(Base):
 

--- a/src/telliot/utils/response.py
+++ b/src/telliot/utils/response.py
@@ -1,6 +1,9 @@
-from typing import Any, Optional
-from telliot.utils.base import Base
+from typing import Any
+from typing import Optional
+
 from telliot.model.endpoints import RPCEndpoint
+from telliot.utils.base import Base
+
 
 class ContractResponse(Base):
 

--- a/src/telliot/utils/response.py
+++ b/src/telliot/utils/response.py
@@ -1,0 +1,17 @@
+from typing import Any, Optional
+from telliot.utils.base import Base
+from telliot.model.endpoints import RPCEndpoint
+from telliot.utils.contract import Contract
+
+
+class ContractResponse(Base):
+
+    ok: bool
+
+    result: Optional[Any]
+
+    error: Optional[Exception]
+
+    error_msg: Optional[str]
+
+    endpoint: Optional[RPCEndpoint]

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -27,9 +27,9 @@ def test_call_read_function():
     """Contract object should be able to call arbitrary contract read function"""
 
     contract = connect_to_contract("0x4699845F22CA2705449CFD532060e04abE3F1F31")
-    data, success = contract.read(func_name=func_name, _requestId=requestId)
-    assert data[0] > 0
-    assert success
+    output = contract.read(func_name=func_name, _requestId=requestId)
+    assert output.result > 0
+    assert output.ok
 
 
 def connect_to_contract(address):
@@ -53,5 +53,5 @@ def test_attempt_read_not_connected():
     c = Contract(node=endpt, address=address, abi=tellor_playground_abi)
     assert c.contract is None
     # read will succeed even if contract is initially diconnected
-    assert c.read(func_name=func_name, _requestId=requestId)[0][0] > 0
-    assert c.read(func_name=func_name, _requestId=requestId)[1]
+    assert c.read(func_name=func_name, _requestId=requestId).result > 0
+    assert c.read(func_name=func_name, _requestId=requestId).ok

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ python =
     3.9: py39
 
 [testenv]
+whitelist_externals=echo
+list_dependencies_command=echo
 passenv = *
 deps =
     -rrequirements.txt


### PR DESCRIPTION
For the sake of troubleshooting, I've stipulating that tox not print the current dependencies to the console. I think this will make troubleshooting easier and reduce console eyesore.

Closes #86 