### PR TITLE
Catch more TX failure reasons

### DIFF
--- a/src/telliot/contract/contract.py
+++ b/src/telliot/contract/contract.py
@@ -184,6 +184,8 @@ class Contract:
                     acc_nonce += 1
                 elif not status.ok and status.error and "nonce too low" in status.error:
                     acc_nonce += 1
+                elif not status.ok and status.error and "not in the chain" in status.error:
+                    extra_gas_price += gas_price
                 else:
                     extra_gas_price = 0
 

--- a/src/telliot/contract/contract.py
+++ b/src/telliot/contract/contract.py
@@ -179,13 +179,17 @@ class Contract:
                     and status.error
                     and "replacement transaction underpriced" in status.error
                 ):
-                    extra_gas_price += gas_price
+                    gas_price += extra_gas_price
                 elif not status.ok and status.error and "already known" in status.error:
                     acc_nonce += 1
                 elif not status.ok and status.error and "nonce too low" in status.error:
                     acc_nonce += 1
-                elif not status.ok and status.error and "not in the chain" in status.error:
-                    extra_gas_price += gas_price
+                elif (
+                    not status.ok
+                    and status.error
+                    and "not in the chain" in status.error
+                ):
+                    gas_price += extra_gas_price
                 else:
                     extra_gas_price = 0
 

--- a/src/telliot/contract/contract.py
+++ b/src/telliot/contract/contract.py
@@ -181,7 +181,7 @@ class Contract:
                 ):
                     extra_gas_price += gas_price
                 elif not status.ok and status.error and "already known" in status.error:
-                    continue
+                    acc_nonce += 1
                 elif not status.ok and status.error and "nonce too low" in status.error:
                     acc_nonce += 1
                 else:

--- a/src/telliot/contract/contract.py
+++ b/src/telliot/contract/contract.py
@@ -182,7 +182,7 @@ class Contract:
                     extra_gas_price += gas_price
                 elif not status.ok and status.error and "already known" in status.error:
                     continue
-                elif not status.ok and status.error and "nonce too low":
+                elif not status.ok and status.error and "nonce too low" in status.error:
                     acc_nonce += 1
                 else:
                     extra_gas_price = 0

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -127,7 +127,7 @@ async def test_submit_value(cfg, master, oracle):
     receipt, status = await oracle.write_with_retry(
         func_name="submitValue",
         gas_price=gas_price,
-        extra_gas_price=20,
+        extra_gas_price=40,
         retries=5,
         _queryId=query_id,
         _value=value,


### PR DESCRIPTION
The intention here is to update the contract class in order to prevent the rpc error "already known", which indicates that the same transaction is being sent a second time with the same nonce.